### PR TITLE
Field set sorting may encounter mixin element that cannot be casted

### DIFF
--- a/mek_data_class_generator/lib/src/field_helpers.dart
+++ b/mek_data_class_generator/lib/src/field_helpers.dart
@@ -31,7 +31,12 @@ class _FieldSet implements Comparable<_FieldSet> {
   int compareTo(_FieldSet other) => _sortByLocation(sortField, other.sortField);
 
   static int _sortByLocation(FieldElement a, FieldElement b) {
-    final checkerA = TypeChecker.fromStatic((a.enclosingElement3 as ClassElement).thisType);
+    var checkerA;
+    if (a.enclosingElement3 is MixinElement) {
+      checkerA = TypeChecker.fromStatic((a.enclosingElement3 as MixinElement).thisType);
+    } else {
+      checkerA = TypeChecker.fromStatic((a.enclosingElement3 as ClassElement).thisType);
+    }
 
     if (!checkerA.isExactly(b.enclosingElement3)) {
       // in this case, you want to prioritize the enclosingElement that is more
@@ -41,7 +46,12 @@ class _FieldSet implements Comparable<_FieldSet> {
         return -1;
       }
 
-      final checkerB = TypeChecker.fromStatic((b.enclosingElement3 as ClassElement).thisType);
+      var checkerB;
+      if (b.enclosingElement3 is MixinElement) {
+        checkerB = TypeChecker.fromStatic((b.enclosingElement3 as MixinElement).thisType);
+      } else {
+        checkerB = TypeChecker.fromStatic((b.enclosingElement3 as ClassElement).thisType);
+      }
 
       if (checkerB.isAssignableFrom(a.enclosingElement3)) {
         return 1;


### PR DESCRIPTION
In the changed function the sorting may encounter a MixinElement that is the generated _self that it's unable to cast to a ClassElement, because they don't share a common ancestor.

If the type checker is handled for mixin and class elements separately it works.

I have no idea why this happens, I had multiple classes using the @DataClass annotation and they worked and one particular class didn't and only randomly. So from a clean state it worked, but on the second change it broke all the time until I removed the mixin did a build it worked after that putting back the mixin it worked the first time then borken from then on.

This change fixes this issue and as far as I see.
