### PR TITLE
Sealed classes, toString null values and lint warning

### DIFF
--- a/.github/workflows/integration_class_to_string.yml
+++ b/.github/workflows/integration_class_to_string.yml
@@ -1,0 +1,38 @@
+name: Integration class_to_string
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: class_to_string
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.0.0
+
+      - name: Resolve dependencies
+        run: dart pub get
+        timeout-minutes: 2
+
+      - name: Check code formatting
+        run: >-
+          dart format --line-length 100 --set-exit-if-changed --output none
+          $(find . ! -path "./.dart_tool/**" ! -path "./build/**" -name "*.dart" ! -name "*.g.dart")
+
+      - name: Analyze code
+        run: dart analyze
+
+      - name: Test code
+        run: dart test ./test

--- a/.github/workflows/integration_mek_data_class.yml
+++ b/.github/workflows/integration_mek_data_class.yml
@@ -1,0 +1,35 @@
+name: Integration mek_data_class
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: mek_data_class
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.0.0
+
+      - name: Resolve dependencies
+        run: dart pub get
+        timeout-minutes: 2
+
+      - name: Check code formatting
+        run: >-
+          dart format --line-length 100 --set-exit-if-changed --output none
+          $(find . ! -path "./.dart_tool/**" ! -path "./build/**" -name "*.dart" ! -name "*.g.dart")
+
+      - name: Analyze code
+        run: dart analyze

--- a/.github/workflows/integration_mek_data_class_generator.yml
+++ b/.github/workflows/integration_mek_data_class_generator.yml
@@ -1,0 +1,35 @@
+name: Integration mek_data_class_generator
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: mek_data_class_generator
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.0.0
+
+      - name: Resolve dependencies
+        run: dart pub get
+        timeout-minutes: 2
+
+      - name: Check code formatting
+        run: >-
+          dart format --line-length 100 --set-exit-if-changed --output none
+          $(find . ! -path "./.dart_tool/**" ! -path "./build/**" -name "*.dart" ! -name "*.g.dart")
+
+      - name: Analyze code
+        run: dart analyze

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ class ProductFields {
 ## Global Configs
 See the docs of the DataClass class for more information
 
+| Key                  | Default  | Description                                                                                        |
+|----------------------|----------|----------------------------------------------------------------------------------------------------|
+| page_width           | `80`     | adjust the page formatting width of the generated dart code                                        |
+| stringify_if_null    | `true`   | if set to `false`, null values will not be included in the toString                                |
+| stringify_type       | `params` | if set to `fields`, fields of a class that are not passed to the constructor will also be included |
+| fields_class_visible | `true`   | if set to `false`, the fields classes is private                                                   |
+
 ```yaml
 # build.yaml
 targets:
@@ -186,10 +193,12 @@ targets:
           comparable: true
           stringify: true
           stringify_type: params | fields
+          stringify_if_null: true
           copyable: false
           changeable: false
           changes_visible: false
           create_fields_class: false
+          fields_class_visible: true
 ```
 
 ### Recommended options

--- a/class_to_string/CHANGELOG.md
+++ b/class_to_string/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.0.3
+## 1.0.0
+- feat: `ClassToString.add` method now stringify a `null` values [#17](https://github.com/BreX900/data_class/issues/17)
 
+## 0.0.3
 - chore: Added support for dart `3.0`
 
 ## 0.0.1

--- a/class_to_string/README.md
+++ b/class_to_string/README.md
@@ -6,7 +6,7 @@ Generally used in code generators for example in [mek_data_class]
 - [x] Supported nested classes
 - [x] Generate a single-line string from a class
 - [x] Generate a multi-line string from a class
-- [ ] Generate a json string from a class
+- [x] Generate a json string from a class
 - [ ] Generate a yaml string from a class
 
 ## Usage

--- a/class_to_string/lib/class_to_string.dart
+++ b/class_to_string/lib/class_to_string.dart
@@ -1,3 +1,4 @@
 library class_to_string;
 
 export 'package:class_to_string/src/class_to_string.dart';
+export 'package:class_to_string/src/class_to_string_base.dart';

--- a/class_to_string/lib/src/class_to_flat_string.dart
+++ b/class_to_string/lib/src/class_to_flat_string.dart
@@ -1,7 +1,8 @@
 import 'package:class_to_string/src/class_to_string.dart';
+import 'package:class_to_string/src/class_to_string_base.dart';
 
 /// A [ClassToString] that produces single line output.
-class ClassToFlatString implements ClassToString {
+class ClassToFlatString extends ClassToStringBase {
   StringBuffer? _result = StringBuffer();
 
   var _hasPreviousField = false;
@@ -21,11 +22,10 @@ class ClassToFlatString implements ClassToString {
   }
 
   @override
-  void add(String field, Object? value) {
-    if (value == null) return;
+  void add(String name, Object? value) {
     if (_hasPreviousField) _result!.write(',');
     _result!
-      ..write(field)
+      ..write(name)
       ..write('=')
       ..write(value);
     _hasPreviousField = true;

--- a/class_to_string/lib/src/class_to_indent_string.dart
+++ b/class_to_string/lib/src/class_to_indent_string.dart
@@ -1,7 +1,8 @@
 import 'package:class_to_string/src/class_to_string.dart';
+import 'package:class_to_string/src/class_to_string_base.dart';
 
 /// A [ClassToString] that produces multi-line indented output.
-class ClassToIndentString implements ClassToString {
+class ClassToIndentString extends ClassToStringBase {
   StringBuffer? _result = StringBuffer();
 
   static var _indentCount = 0;
@@ -24,15 +25,14 @@ class ClassToIndentString implements ClassToString {
   }
 
   @override
-  void add(String field, Object? value) {
-    if (value == null) return;
+  void add(String name, Object? value) {
     if (_isEmpty) {
       _isEmpty = false;
       _result!.writeln();
     }
     _result!
       ..write(' ' * _indentCount)
-      ..write(field)
+      ..write(name)
       ..write('=')
       ..write(value)
       ..write(',\n');

--- a/class_to_string/lib/src/class_to_json_string.dart
+++ b/class_to_string/lib/src/class_to_json_string.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 
 import 'package:class_to_string/src/class_to_string.dart';
+import 'package:class_to_string/src/class_to_string_base.dart';
 
 /// A [ClassToString] that produces single line output.
 ///
 /// Note: this is an experimental feature. API may change without a major
 /// version increase.
-class ClassToJsonString implements ClassToString {
+class ClassToJsonString extends ClassToStringBase {
   StringBuffer? _result = StringBuffer();
   Map<String, dynamic>? _result2 = {};
 
@@ -30,15 +31,19 @@ class ClassToJsonString implements ClassToString {
   }
 
   @override
-  void add(String field, Object? value) {
-    if (value == null) return;
-    _result2![field] = value;
+  void add(String name, Object? value) {
+    _result2![name] = value;
 
     _result!
       ..write(',"')
-      ..write(field)
+      ..write(name)
       ..write('":');
-    if (value is num || value is bool || value is String || value is List || value is Map) {
+    if (value == null ||
+        value is num ||
+        value is bool ||
+        value is String ||
+        value is List ||
+        value is Map) {
       _result!.write(jsonEncode(value));
     } else {
       final result = value.toString();

--- a/class_to_string/lib/src/class_to_string.dart
+++ b/class_to_string/lib/src/class_to_string.dart
@@ -1,15 +1,16 @@
 import 'package:class_to_string/src/class_to_flat_string.dart';
 import 'package:class_to_string/src/class_to_indent_string.dart';
+import 'package:class_to_string/src/class_to_json_string.dart';
 
 /// Interface for [Object.toString] output pretty class to string.
 abstract class ClassToString {
   /// Override this method to change the way a class's toString is generated
-  static ClassToString Function(String name, [Iterable<Type>? types])? creator;
+  static ClassToString Function(String className, [Iterable<Type> types])? creator;
 
   /// Constructor to use the default [ClassToString]
-  factory ClassToString(String name, [Iterable<Type> types = const []]) {
-    if (creator != null) return creator!(name, types);
-    return ClassToIndentString(name, types);
+  factory ClassToString(String className, [Iterable<Type> types = const []]) {
+    if (creator != null) return creator!(className, types);
+    return ClassToIndentString(className, types);
   }
 
   /// A [ClassToString] that produces single line output.
@@ -18,8 +19,14 @@ abstract class ClassToString {
   /// A [ClassToString] that produces multi-line indented output.
   factory ClassToString.indent(String name, [Iterable<Type> types]) = ClassToIndentString;
 
-  /// Add a field and its value.
-  void add(String field, Object? value);
+  /// A [ClassToString] that produces multi-line indented output.
+  factory ClassToString.json(String name, [Iterable<Type> types]) = ClassToJsonString;
+
+  /// Add param or field and its nullable value.
+  void add(String name, Object? value);
+
+  /// Add param or field and its value.
+  void addIfExist(String name, Object? value);
 
   /// Returns to completed toString(). The helper may not be used after this
   /// method is called.

--- a/class_to_string/lib/src/class_to_string_base.dart
+++ b/class_to_string/lib/src/class_to_string_base.dart
@@ -1,0 +1,9 @@
+import 'package:class_to_string/src/class_to_string.dart';
+
+abstract class ClassToStringBase implements ClassToString {
+  @override
+  void addIfExist(String name, Object? value) {
+    if (value == null) return;
+    add(name, value);
+  }
+}

--- a/class_to_string/pubspec.yaml
+++ b/class_to_string/pubspec.yaml
@@ -1,11 +1,14 @@
 name: class_to_string
 description: It allows to get beautiful class to string.
-version: 0.0.3
+version: 1.0.0
 homepage: https://github.com/BreX900/data_class/tree/main/class_to_string
 repository: https://github.com/BreX900/data_class
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+
+scripts:
+  publish: dart pub publish
 
 dev_dependencies:
   mek_lints: ^1.0.0

--- a/class_to_string/test/class_to_flat_string_test.dart
+++ b/class_to_string/test/class_to_flat_string_test.dart
@@ -17,9 +17,10 @@ void main() {
         ..add('double', 1.1)
         ..add('boolean', true)
         ..add('string', 'text')
-        ..add('nullable', null));
+        ..add('null', null)
+        ..addIfExist('nullable', null));
 
-      expect(object.toString(), 'Filled(integer=1,double=1.1,boolean=true,string=text)');
+      expect(object.toString(), 'Filled(integer=1,double=1.1,boolean=true,string=text,null=null)');
     });
 
     test('inner flat class', () {

--- a/class_to_string/test/class_to_indent_string_test.dart
+++ b/class_to_string/test/class_to_indent_string_test.dart
@@ -17,7 +17,8 @@ void main() {
         ..add('double', 1.1)
         ..add('boolean', true)
         ..add('string', 'text')
-        ..add('nullable', null));
+        ..add('null', null)
+        ..addIfExist('nullable', null));
 
       expect(
         object.toString(),
@@ -26,6 +27,7 @@ void main() {
         '  double=1.1,\n'
         '  boolean=true,\n'
         '  string=text,\n'
+        '  null=null,\n'
         ')',
       );
     });

--- a/class_to_string/test/class_to_json_string_test.dart
+++ b/class_to_string/test/class_to_json_string_test.dart
@@ -17,10 +17,11 @@ void main() {
         ..add('double', 1.1)
         ..add('boolean', true)
         ..add('string', 'text')
-        ..add('nullable', null));
+        ..add('null', null)
+        ..addIfExist('nullable', null));
 
       expect(object.toString(),
-          '{"\$className":"Filled","integer":1,"double":1.1,"boolean":true,"string":"text"}');
+          '{"\$className":"Filled","integer":1,"double":1.1,"boolean":true,"string":"text","null":null}');
     });
 
     test('inner flat class', () {

--- a/example/lib/basic_example.g.dart
+++ b/example/lib/basic_example.g.dart
@@ -110,5 +110,5 @@ mixin _$EmptyClass {
   }
 
   @override
-  String toString() => (ClassToString('EmptyClass')).toString();
+  String toString() => ClassToString('EmptyClass').toString();
 }

--- a/example/lib/generics_example.dart
+++ b/example/lib/generics_example.dart
@@ -3,7 +3,7 @@ import 'package:mek_data_class/mek_data_class.dart';
 part 'generics_example.g.dart';
 
 @DataClass(changeable: true, copyable: true)
-class Response<T> with _$Response<T> {
+sealed class Response<T> with _$Response<T> {
   final T data;
 
   const Response({
@@ -12,7 +12,7 @@ class Response<T> with _$Response<T> {
 }
 
 @DataClass(changeable: true, copyable: true)
-class PaginatedResponse<T extends Object> extends Response<T> with _$PaginatedResponse<T> {
+final class PaginatedResponse<T extends Object> extends Response<T> with _$PaginatedResponse<T> {
   final int total;
 
   const PaginatedResponse({
@@ -22,7 +22,7 @@ class PaginatedResponse<T extends Object> extends Response<T> with _$PaginatedRe
 }
 
 @DataClass(changeable: true, copyable: true)
-class ListResponse<T> extends Response<List<T>> with _$ListResponse<T> {
+base class ListResponse<T> extends Response<List<T>> with _$ListResponse<T> {
   ListResponse({
     required List<T> data,
   }) : super(data: data);

--- a/example/lib/generics_example.g.dart
+++ b/example/lib/generics_example.g.dart
@@ -24,26 +24,18 @@ mixin _$Response<T> {
   @override
   String toString() =>
       (ClassToString('Response', [T])..add('data', _self.data)).toString();
-  Response<T> copyWith({T? data}) {
-    return Response(
-      data: data ?? _self.data,
-    );
-  }
-
-  Response<T> change(void Function(_ResponseChanges<T> c) updates) =>
-      (_ResponseChanges<T>._(_self)..update(updates)).build();
-  _ResponseChanges<T> toChanges() => _ResponseChanges._(_self);
+  Response<T> copyWith({T? data});
+  Response<T> change(void Function(_ResponseChanges<T> c) updates);
+  _ResponseChanges<T> toChanges();
 }
 
-class _ResponseChanges<T> {
+abstract class _ResponseChanges<T> {
   _ResponseChanges._(Response<T> dc) : data = dc.data;
 
   T data;
 
-  void update(void Function(_ResponseChanges<T> c) updates) => updates(this);
-  Response<T> build() => Response(
-        data: data,
-      );
+  void update(void Function(_ResponseChanges<T> c) updates);
+  Response<T> build();
 }
 
 mixin _$PaginatedResponse<T extends Object> {

--- a/example/lib/inheritance_example.dart
+++ b/example/lib/inheritance_example.dart
@@ -34,7 +34,7 @@ class Dog extends Animal with Action, _$Dog {
 }
 
 @DataClass(changeable: true, copyable: true)
-class Cat extends Animal with Action, _$Cat {
+class Cat extends Animal with Action, Description, _$Cat {
   @override
   final String getterField;
 
@@ -54,6 +54,8 @@ mixin Action {
   String get name;
 
   String say();
+}
 
-  String get action => '$name say ${say()}';
+mixin Description on Action {
+  late final String description = '$name: ${say()}';
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 scripts:
   # To generate .g files:
@@ -11,7 +11,7 @@ scripts:
 dependencies:
   collection: ^1.16.0
   mek_data_class: ^0.0.0
-  json_annotation: ^4.7.0
+  json_annotation: ^4.8.1
 
 dependency_overrides:
   class_to_string:
@@ -26,4 +26,4 @@ dev_dependencies:
   build_runner: ^2.3.2
   mek_data_class_generator:
     path: ../mek_data_class_generator
-  json_serializable: ^6.5.4
+  json_serializable: ^6.7.0

--- a/mek_data_class/CHANGELOG.md
+++ b/mek_data_class/CHANGELOG.md
@@ -1,6 +1,8 @@
 
-## 1.1.0
+## 1.2.0
+- chore: update `class_to_string` dependency to `1.0.0`
 
+## 1.1.0
 - feat: You can pass your `Equality` classes to `DataClass(equalities: [...])`
 - chore: Added support for dart `3.0`
 

--- a/mek_data_class/pubspec.yaml
+++ b/mek_data_class/pubspec.yaml
@@ -1,15 +1,22 @@
 name: mek_data_class
 description: >
   Generate `hashCode`, `==`, `toString`, `copyWith` and `change` methods with low code
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/BreX900/data_class/tree/main/mek_data_class
 repository: https://github.com/BreX900/data_class
+topics:
+  - data-class
+  - build-runner
+  - codegen
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+
+scripts:
+  publish: dart pub publish
 
 dependencies:
-  class_to_string: ^0.0.2
+  class_to_string: ^1.0.0
 
   meta: ^1.7.0
   collection: ^1.15.0

--- a/mek_data_class_generator/CHANGELOG.md
+++ b/mek_data_class_generator/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 1.3.0
+- fix: unnecessary parentheses on `toString` method [#20](https://github.com/BreX900/data_class/issues/20)
+- fix: `Classes and mixins can only implement other classes and mixins` error [#19](https://github.com/BreX900/data_class/issues/19)
+- feat: `toString` method now print `null` values [#17](https://github.com/BreX900/data_class/issues/17), you can change this behavior by setting the yaml file `stringify_if_null: false`
+
 ## 1.2.0
 
 - feat: You can pass your `Equality` classes to `DataClass(equalities: [...])`

--- a/mek_data_class_generator/lib/src/configs.dart
+++ b/mek_data_class_generator/lib/src/configs.dart
@@ -10,20 +10,24 @@ class Config {
   final bool comparable;
   final bool stringify;
   final StringifyType stringifyType;
+  final bool stringifyIfNull;
   final bool copyable;
   final bool changeable;
   final bool changesVisible;
   final bool createFieldsClass;
+  final bool fieldsClassVisible;
 
   const Config({
     this.pageWidth = 80,
     this.comparable = true,
     this.stringify = true,
     this.stringifyType = StringifyType.params,
+    this.stringifyIfNull = true,
     this.copyable = false,
     this.changeable = false,
     this.changesVisible = false,
     this.createFieldsClass = false,
+    this.fieldsClassVisible = true,
   });
 
   factory Config.fromJson(Map<String, dynamic> map) => _$ConfigFromJson(map);

--- a/mek_data_class_generator/lib/src/configs.g.dart
+++ b/mek_data_class_generator/lib/src/configs.g.dart
@@ -17,10 +17,12 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
             'comparable',
             'stringify',
             'stringify_type',
+            'stringify_if_null',
             'copyable',
             'changeable',
             'changes_visible',
-            'create_fields_class'
+            'create_fields_class',
+            'fields_class_visible'
           ],
         );
         final val = Config(
@@ -32,20 +34,26 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
               (v) =>
                   $enumDecodeNullable(_$StringifyTypeEnumMap, v) ??
                   StringifyType.params),
+          stringifyIfNull:
+              $checkedConvert('stringify_if_null', (v) => v as bool? ?? true),
           copyable: $checkedConvert('copyable', (v) => v as bool? ?? false),
           changeable: $checkedConvert('changeable', (v) => v as bool? ?? false),
           changesVisible:
               $checkedConvert('changes_visible', (v) => v as bool? ?? false),
           createFieldsClass: $checkedConvert(
               'create_fields_class', (v) => v as bool? ?? false),
+          fieldsClassVisible: $checkedConvert(
+              'fields_class_visible', (v) => v as bool? ?? true),
         );
         return val;
       },
       fieldKeyMap: const {
         'pageWidth': 'page_width',
         'stringifyType': 'stringify_type',
+        'stringifyIfNull': 'stringify_if_null',
         'changesVisible': 'changes_visible',
-        'createFieldsClass': 'create_fields_class'
+        'createFieldsClass': 'create_fields_class',
+        'fieldsClassVisible': 'fields_class_visible'
       },
     );
 

--- a/mek_data_class_generator/lib/src/creators/changes_creator.dart
+++ b/mek_data_class_generator/lib/src/creators/changes_creator.dart
@@ -68,15 +68,15 @@ class ChangesCreator extends Creator {
     var superFieldsName = const <String>[];
     String? implement;
     if (superType != null) {
-      final superElement = superType.element2 as ClassElement;
+      final superElement = superType.element as ClassElement;
       final superSpec = ClassSpec.from(
         config,
         superElement,
-        ConstantReader(dataClassChecker.firstAnnotationOf(superType.element2)),
+        ConstantReader(dataClassChecker.firstAnnotationOf(superType.element)),
       );
 
       final superTypes = ClassSpec.t(superType.typeArguments.join(', '));
-      final superName = '${visibility(superSpec.changesVisible)}${superType.element2.name}Changes';
+      final superName = '${visibility(superSpec.changesVisible)}${superType.element.name}Changes';
       implement = '$superName$superTypes';
       superFieldsName = superElement.fields.where(isDataClassField).map((e) => e.name).toList();
     }

--- a/mek_data_class_generator/lib/src/creators/equality_creator.dart
+++ b/mek_data_class_generator/lib/src/creators/equality_creator.dart
@@ -31,10 +31,10 @@ class EqualityCreator extends Creator {
 
   String? _codeEqualityClasses(DartType type) {
     for (final equality in classSpec.equalities) {
-      final extendedEqualityClassElement = equality.type!.element2 as ClassElement;
+      final extendedEqualityClassElement = equality.type!.element as ClassElement;
       final equalityClassElement =
           extendedEqualityClassElement.allSupertypes.singleWhereOrNull((e) {
-        return _equalityChecker.isExactly(e.element2);
+        return _equalityChecker.isExactly(e.element);
       });
       if (equalityClassElement == null) continue;
 

--- a/mek_data_class_generator/lib/src/creators/fields_class_creator.dart
+++ b/mek_data_class_generator/lib/src/creators/fields_class_creator.dart
@@ -33,7 +33,7 @@ class FieldsClassCreator extends Creator {
   }
 
   Method? _createMethodField(FieldSpec fieldSpec, String fieldPath) {
-    final fieldClassElement = fieldSpec.element.type.element2;
+    final fieldClassElement = fieldSpec.element.type.element;
     if (fieldClassElement is! ClassElement) return null;
 
     final fieldClassReader = dataClassAnnotation(fieldClassElement);
@@ -56,7 +56,7 @@ class FieldsClassCreator extends Creator {
     final jsonSerializable = _jsonSerializableType.firstAnnotationOf(classSpec.element);
     final hasFieldMap = ConstantReader(jsonSerializable).peek('createFieldMap')?.boolValue ?? false;
 
-    final className = '${classSpec.element.name}Fields';
+    final className = '${config.fieldsClassVisible ? '' : '_'}${classSpec.element.name}Fields';
 
     final methodsFields = _paramsSpecs.map((field) {
       final fieldPath = _createFieldPath(field, hasFieldMap);

--- a/mek_data_class_generator/lib/src/creators/to_string_creator.dart
+++ b/mek_data_class_generator/lib/src/creators/to_string_creator.dart
@@ -22,7 +22,6 @@ class ToStringCreator extends Creator {
         fieldSpecs = fieldSpecs.where((field) => field.isParam).toList();
         break;
       case StringifyType.fields:
-        break;
     }
     return fieldSpecs;
   })();
@@ -36,17 +35,21 @@ class ToStringCreator extends Creator {
     final types = classSpec.types.isEmpty ? '' : ', ${classSpec.types}';
 
     final fields = _effectiveFieldSpecs.map((field) {
+      final addType = classSpec.stringifyIfNull ? 'add' : 'addIfExist';
       final variable = '_self.${field.name}';
       final stringifier = field.stringifier;
       final stringifyVariable = stringifier != null ? '$stringifier($variable)' : variable;
-      return '..add(\'${field.name}\', $stringifyVariable)';
+      return '..$addType(\'${field.name}\', $stringifyVariable)';
     });
+
+    final classToString = "ClassToString('${classSpec.self.name}'$types)${fields.join()}";
 
     return Method((b) => b
       ..annotations.add(Annotations.override)
       ..returns = Refs.string
       ..name = 'toString'
       ..lambda = true
-      ..body = Code("(ClassToString('${classSpec.self.name}'$types)${fields.join()}).toString()"));
+      ..body =
+          Code("${_effectiveFieldSpecs.isEmpty ? classToString : '($classToString)'}.toString()"));
   }
 }

--- a/mek_data_class_generator/lib/src/field_helpers.dart
+++ b/mek_data_class_generator/lib/src/field_helpers.dart
@@ -31,19 +31,19 @@ class _FieldSet implements Comparable<_FieldSet> {
   int compareTo(_FieldSet other) => _sortByLocation(sortField, other.sortField);
 
   static int _sortByLocation(FieldElement a, FieldElement b) {
-    final checkerA = TypeChecker.fromStatic((a.enclosingElement3 as InterfaceElement).thisType);
+    final checkerA = TypeChecker.fromStatic((a.enclosingElement as InterfaceElement).thisType);
 
-    if (!checkerA.isExactly(b.enclosingElement3)) {
+    if (!checkerA.isExactly(b.enclosingElement)) {
       // in this case, you want to prioritize the enclosingElement that is more
       // "super".
 
-      if (checkerA.isAssignableFrom(b.enclosingElement3)) {
+      if (checkerA.isAssignableFrom(b.enclosingElement)) {
         return -1;
       }
 
-      final checkerB = TypeChecker.fromStatic((b.enclosingElement3 as InterfaceElement).thisType);
+      final checkerB = TypeChecker.fromStatic((b.enclosingElement as InterfaceElement).thisType);
 
-      if (checkerB.isAssignableFrom(a.enclosingElement3)) {
+      if (checkerB.isAssignableFrom(a.enclosingElement)) {
         return 1;
       }
     }
@@ -75,7 +75,7 @@ List<FieldElement> createSortedFieldSet(ClassElement element) {
 
   for (final v in manager.getInheritedConcreteMap2(element).values) {
     assert(v is! FieldElement);
-    if (_dartCoreObjectChecker.isExactly(v.enclosingElement3)) {
+    if (_dartCoreObjectChecker.isExactly(v.enclosingElement)) {
       continue;
     }
 

--- a/mek_data_class_generator/lib/src/specs.dart
+++ b/mek_data_class_generator/lib/src/specs.dart
@@ -29,6 +29,7 @@ class ClassSpec {
   final bool comparable;
   final bool stringify;
   final StringifyType stringifyType;
+  final bool stringifyIfNull;
   final bool copyable;
   final bool changeable;
   final bool changesVisible;
@@ -42,6 +43,7 @@ class ClassSpec {
     required this.copyable,
     required this.stringify,
     required this.stringifyType,
+    required this.stringifyIfNull,
     required this.changeable,
     required this.changesVisible,
     required this.createFieldsClass,
@@ -82,6 +84,7 @@ class ClassSpec {
       comparable: annotation.peek('comparable')?.boolValue ?? config.comparable,
       stringify: annotation.peek('stringify')?.boolValue ?? config.stringify,
       stringifyType: config.stringifyType,
+      stringifyIfNull: config.stringifyIfNull,
       copyable: annotation.peek('copyable')?.boolValue ?? config.copyable,
       changeable: annotation.peek('changeable')?.boolValue ?? config.changeable,
       changesVisible: annotation.peek('changesVisible')?.boolValue ?? config.changesVisible,
@@ -113,7 +116,7 @@ class FieldSpec {
   final String? stringifier;
   final bool updatable;
 
-  late final bool isParam = _isParam(element.enclosingElement3 as ClassElement, element);
+  late final bool isParam = _isParam(element.enclosingElement as InterfaceElement, element);
 
   FieldSpec({
     required this.parsedLibrary,
@@ -151,7 +154,7 @@ class FieldSpec {
       return e.namespace.definedNames.values;
     });
 
-    final type = prefixedElements.contains(element.type.element2)
+    final type = prefixedElements.contains(element.type.element)
         ? _getTypeWithPrefix(parsedLibrary, element)
         : _getType(element.type);
 
@@ -196,11 +199,12 @@ class FieldSpec {
     }
   }
 
-  static bool _isParam(ClassElement classElement, FieldElement element) {
+  static bool _isParam(InterfaceElement classOrMixinElement, FieldElement element) {
     if (element.isPrivate) return false;
     if (element.hasInitializer) return false;
 
-    final constructorElement = classElement.unnamedConstructor ?? classElement.constructors.first;
+    final constructorElement =
+        classOrMixinElement.unnamedConstructor ?? classOrMixinElement.constructors.first;
     return constructorElement.parameters.any((e) => e.name == element.name);
   }
 }

--- a/mek_data_class_generator/lib/src/utils.dart
+++ b/mek_data_class_generator/lib/src/utils.dart
@@ -26,10 +26,10 @@ ConstantReader? dataClassAnnotation(ClassElement element) {
 InterfaceType? findSuperDataClass(ClassElement element) {
   InterfaceType? superType = element.supertype;
   while (superType != null) {
-    if (dataClassChecker.hasAnnotationOf(superType.element2)) {
+    if (dataClassChecker.hasAnnotationOf(superType.element)) {
       return superType;
     }
-    superType = superType.element2.supertype;
+    superType = superType.element.supertype;
   }
   return null;
 }
@@ -41,5 +41,5 @@ bool isDataClassField(FieldElement field) {
 }
 
 extension DartTypeExtension on DartType {
-  DartType promoteNonNullable() => element2?.library?.typeSystem.promoteToNonNull(this) ?? this;
+  DartType promoteNonNullable() => element?.library?.typeSystem.promoteToNonNull(this) ?? this;
 }

--- a/mek_data_class_generator/pubspec.yaml
+++ b/mek_data_class_generator/pubspec.yaml
@@ -1,13 +1,17 @@
 name: mek_data_class_generator
-version: 1.2.0
+version: 1.3.0
 description: >
   Code generator for data_class to generate `hashCode`, `==`, `toString`, `copyWith` 
   and `change` methods
 homepage: https://github.com/BreX900/data_class/tree/main/mek_data_class_generator
 repository: https://github.com/BreX900/data_class
+topics:
+  - data-class
+  - build-runner
+  - codegen
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 scripts:
   publish: dart pub publish
@@ -15,17 +19,17 @@ scripts:
   build:runner: dart run build_runner watch --delete-conflicting-outputs
 
 dependencies:
-  mek_data_class: ^1.1.0
+  mek_data_class: ^1.2.0
 
-  analyzer: ">=4.6.0 <6.0.0"
+  analyzer: ^5.12.0
   build: ^2.0.0
-  source_gen: ^1.2.0
-  dart_style: ^2.2.0
-  code_builder: ^4.4.0
+  source_gen: ^1.3.2
+  dart_style: ^2.3.1
+  code_builder: ^4.5.0
 
   collection: ^1.16.0
 
-  json_annotation: ^4.7.0
+  json_annotation: ^4.8.1
 
 dependency_overrides:
   class_to_string:
@@ -37,5 +41,5 @@ dev_dependencies:
   mek_lints: ^1.0.0
   test: ^1.21.6
 
-  build_runner: ^2.3.3
+  build_runner: ^2.4.5
   json_serializable: ^6.5.4


### PR DESCRIPTION
build(class_to_string): release 1.0.0
build(mek_data_class): release 1.2.0
build(mek_data_class_generator): release 1.3.0
fix: unnecessary parentheses on `toString` method [#20](https://github.com/BreX900/data_class/issues/20)
fix: `Classes and mixins can only implement other classes and mixins` error [#19](https://github.com/BreX900/data_class/issues/19)
feat: `toString` method now print `null` values [#17](https://github.com/BreX900/data_class/issues/17), you can change this behavior by setting the yaml file `stringify_if_null: false`