### PR TITLE
feat: support change `*Fields` class visibility by `DataClass.fieldsClassVisible` param

### DIFF
--- a/example/lib/fields_class_example.dart
+++ b/example/lib/fields_class_example.dart
@@ -14,10 +14,10 @@ class Father with _$Father {
   });
 }
 
-@DataClass(createFieldsClass: true)
+@DataClass(createFieldsClass: true, fieldsClassVisible: false)
 @JsonSerializable(createFieldMap: true)
 class Mother with _$Mother {
-  static final fields = MotherFields();
+  static final fields = _MotherFields();
 
   @JsonKey(name: 'myChild')
   final Child child;

--- a/example/lib/fields_class_example.g.dart
+++ b/example/lib/fields_class_example.g.dart
@@ -56,14 +56,15 @@ mixin _$Mother {
       (ClassToString('Mother')..add('child', _self.child)).toString();
 }
 
-class MotherFields {
-  const MotherFields([this._path = '']);
+class _MotherFields {
+  // ignore: unused_element
+  const _MotherFields([this._path = '']);
 
   final String _path;
 
   ChildFields get child => ChildFields('$_path${_get('child')}.');
   @override
-  String toString() => _path.isEmpty ? 'MotherFields()' : _path;
+  String toString() => _path.isEmpty ? '_MotherFields()' : _path;
   String _get(String key) => _$MotherFieldMap[key]!;
 }
 

--- a/mek_data_class/CHANGELOG.md
+++ b/mek_data_class/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.3.0
+- feat: support change `*Fields` class visibility by `DataClass.fieldsClassVisible` param
 
 ## 1.2.0
 - chore: update `class_to_string` dependency to `1.0.0`

--- a/mek_data_class/lib/mek_data_class.dart
+++ b/mek_data_class/lib/mek_data_class.dart
@@ -41,6 +41,10 @@ class DataClass {
   /// Default: `false`
   final bool? createFieldsClass;
 
+  /// Makes public the `*Fields` classes generated when [createFieldsClass] is enabled.
+  /// Default: `true`
+  final bool? fieldsClassVisible;
+
   /// This equality is used in the following methods [Object.==] and [Object.hashCode].
   final List<Equality<dynamic>> equalities;
 
@@ -54,6 +58,7 @@ class DataClass {
     this.changeable,
     this.changesVisible,
     this.createFieldsClass,
+    this.fieldsClassVisible,
     this.equalities = const [],
   });
 

--- a/mek_data_class/pubspec.yaml
+++ b/mek_data_class/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mek_data_class
 description: >
   Generate `hashCode`, `==`, `toString`, `copyWith` and `change` methods with low code
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/BreX900/data_class/tree/main/mek_data_class
 repository: https://github.com/BreX900/data_class
 topics:

--- a/mek_data_class_generator/CHANGELOG.md
+++ b/mek_data_class_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+- feat: support change `*Fields` class visibility by `DataClass.fieldsClassVisible` param
+- fix: suppress `unused_element` lint when `*Fields` class is private
+
 ## 1.3.1
 - fix: private fields class generation
 

--- a/mek_data_class_generator/lib/src/creators/fields_class_creator.dart
+++ b/mek_data_class_generator/lib/src/creators/fields_class_creator.dart
@@ -28,8 +28,6 @@ class FieldsClassCreator extends Creator {
     yield createLibraryClassFields();
   }
 
-  String get _classPrefix => config.fieldsClassVisible ? '' : '_';
-
   String _createFieldPath(FieldSpec fieldSpec, bool hasFieldMap) {
     return hasFieldMap ? '\$_path\${_get(\'${fieldSpec.name}\')}' : '\${_path}${fieldSpec.name}';
   }
@@ -44,7 +42,8 @@ class FieldsClassCreator extends Creator {
     final fieldClassSpec = ClassSpec.from(config, fieldClassElement, fieldClassReader);
     if (!fieldClassSpec.createFieldsClass) return null;
 
-    final keysClassName = '$_classPrefix${fieldClassElement.name}Fields';
+    final keysClassName =
+        '${fieldClassSpec.fieldsClassVisible ? '' : '_'}${fieldClassElement.name}Fields';
 
     return Method((b) => b
       ..returns = Reference(keysClassName)
@@ -58,7 +57,7 @@ class FieldsClassCreator extends Creator {
     final jsonSerializable = _jsonSerializableType.firstAnnotationOf(classSpec.element);
     final hasFieldMap = ConstantReader(jsonSerializable).peek('createFieldMap')?.boolValue ?? false;
 
-    final className = '$_classPrefix${classSpec.element.name}Fields';
+    final className = '${classSpec.fieldsClassVisible ? '' : '_'}${classSpec.element.name}Fields';
 
     final methodsFields = _paramsSpecs.map((field) {
       final fieldPath = _createFieldPath(field, hasFieldMap);
@@ -81,6 +80,7 @@ class FieldsClassCreator extends Creator {
         ..type = Refs.string
         ..name = '_path'))
       ..constructors.add(Constructor((b) => b
+        ..docs.returnIf(!classSpec.fieldsClassVisible)?.add('// ignore: unused_element')
         ..constant = true
         ..optionalParameters.add(Parameter((b) => b
           ..toThis = true

--- a/mek_data_class_generator/lib/src/specs.dart
+++ b/mek_data_class_generator/lib/src/specs.dart
@@ -34,6 +34,7 @@ class ClassSpec {
   final bool changeable;
   final bool changesVisible;
   final bool createFieldsClass;
+  final bool fieldsClassVisible;
   final List<DartObject> equalities;
 
   ClassSpec({
@@ -47,6 +48,7 @@ class ClassSpec {
     required this.changeable,
     required this.changesVisible,
     required this.createFieldsClass,
+    required this.fieldsClassVisible,
     required this.equalities,
   });
 
@@ -90,6 +92,8 @@ class ClassSpec {
       changesVisible: annotation.peek('changesVisible')?.boolValue ?? config.changesVisible,
       createFieldsClass:
           annotation.peek('createFieldsClass')?.boolValue ?? config.createFieldsClass,
+      fieldsClassVisible:
+          annotation.peek('fieldsClassVisible')?.boolValue ?? config.fieldsClassVisible,
       equalities: annotation.peek('equalities')!.listValue,
     );
   }

--- a/mek_data_class_generator/pubspec.yaml
+++ b/mek_data_class_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mek_data_class_generator
-version: 1.3.1
+version: 1.4.0
 description: >
   Code generator for data_class to generate `hashCode`, `==`, `toString`, `copyWith` 
   and `change` methods
@@ -19,7 +19,7 @@ scripts:
   build:runner: dart run build_runner watch --delete-conflicting-outputs
 
 dependencies:
-  mek_data_class: ^1.2.0
+  mek_data_class: ^1.3.0
 
   analyzer: ^5.12.0
   build: ^2.0.0


### PR DESCRIPTION


fix: suppress `unused_element` lint when `*Fields` class is private