### PR TITLE
Fix: const constructors generation, missing space

### DIFF
--- a/mek_data_class_generator/lib/src/helpers/helper_core.dart
+++ b/mek_data_class_generator/lib/src/helpers/helper_core.dart
@@ -43,7 +43,7 @@ abstract class HelperCore extends ClassElements {
     void Function(FormalParameterElement parameter) writer,
   ) {
     if (constructor.formalParameters.isEmpty) {
-      if (constructor.isConst) buffer.write('const');
+      if (constructor.isConst) buffer.write('const ');
       buffer.write(constructor.displayName);
       buffer.write('()');
     } else {


### PR DESCRIPTION
const constructors causes invalid generated code 