### PR TITLE
Generate `merge` method

### DIFF
--- a/.github/workflows/integration_class_to_string.yml
+++ b/.github/workflows/integration_class_to_string.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: 3.8.0
 
       - name: Resolve dependencies
         run: dart pub get

--- a/.github/workflows/integration_mek_data_class.yml
+++ b/.github/workflows/integration_mek_data_class.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: 3.8.0
 
       - name: Resolve dependencies
         run: dart pub get

--- a/.github/workflows/integration_mek_data_class_generator.yml
+++ b/.github/workflows/integration_mek_data_class_generator.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: 3.8.0
 
       - name: Resolve dependencies
         run: dart pub get

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Auto generation of:
 - [x] `hashCode` and `==` methods
 - [x] pretty `toString` method
 - [x] `copyWith` method with support a `null` values
+- [x] `merge` to merge current instance values with another
 - [x] `*Changes` class to updated your data class
 - [x] `*Builder` class to build or update your data class
 

--- a/class_to_string/lib/src/class_to_flat_string.dart
+++ b/class_to_string/lib/src/class_to_flat_string.dart
@@ -6,7 +6,7 @@ import 'package:class_to_string/src/utils.dart';
 class ClassToFlatString extends ClassToStringBase {
   StringBuffer? _result = StringBuffer();
 
-  var _hasPreviousField = false;
+  var _isEmpty = true;
 
   ClassToFlatString(String className, [Iterable<Type> types = const []]) {
     _result!.write(className);
@@ -24,12 +24,15 @@ class ClassToFlatString extends ClassToStringBase {
 
   @override
   void add(String name, Object? value) {
-    if (_hasPreviousField) _result!.write(',');
+    if (_isEmpty) {
+      _isEmpty = false;
+    } else {
+      _result!.write(',');
+    }
     _result!
       ..write(name)
       ..write(':')
       ..writeValue(value);
-    _hasPreviousField = true;
   }
 
   @override
@@ -37,6 +40,7 @@ class ClassToFlatString extends ClassToStringBase {
     _result!.write(')');
     final stringResult = _result.toString();
     _result = null;
+    _isEmpty = true;
     return stringResult;
   }
 }

--- a/class_to_string/lib/src/class_to_indent_string.dart
+++ b/class_to_string/lib/src/class_to_indent_string.dart
@@ -46,6 +46,7 @@ class ClassToIndentString extends ClassToStringBase {
     _result!.write(')');
     final stringResult = _result.toString();
     _result = null;
+    _isEmpty = true;
     return stringResult;
   }
 }

--- a/example/lib/basic_example.dart
+++ b/example/lib/basic_example.dart
@@ -49,7 +49,7 @@ class ProductEquality implements Equality<Product> {
   bool isValidKey(Object? o) => throw UnimplementedError();
 }
 
-@DataClass(changeable: true)
+@DataClass(buildable: true, copyable: true, mergeable: true, changeable: true)
 class EmptyClass with _$EmptyClass {
   const EmptyClass._();
 }

--- a/example/lib/basic_example.g.dart
+++ b/example/lib/basic_example.g.dart
@@ -156,10 +156,19 @@ class ProductChanges {
 mixin _$EmptyClass {
   EmptyClass get _self => this as EmptyClass;
 
+  EmptyClass copyWith() => _self;
+
+  EmptyClass merge(covariant EmptyClass? other) => _self;
+
   EmptyClass change(void Function(EmptyClassChanges c) updates) =>
       (toChanges()..update(updates)).build();
 
   EmptyClassChanges toChanges() => EmptyClassChanges._(_self);
+
+  EmptyClass rebuild(void Function(EmptyClassBuilder b) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  EmptyClassBuilder toBuilder() => EmptyClassBuilder()..replace(_self);
 
   @override
   bool operator ==(Object other) =>
@@ -184,4 +193,14 @@ class EmptyClassChanges {
   void update(void Function(EmptyClassChanges c) updates) => updates(this);
 
   EmptyClass build() => _original;
+}
+
+class EmptyClassBuilder {
+  void update(void Function(EmptyClassBuilder b) updates) => updates(this);
+
+  EmptyClass build() {
+    return const EmptyClass._();
+  }
+
+  void replace(covariant EmptyClass other) {}
 }

--- a/example/lib/edge_cases.dart
+++ b/example/lib/edge_cases.dart
@@ -2,7 +2,7 @@ import 'package:mek_data_class/mek_data_class.dart';
 
 part 'edge_cases.g.dart';
 
-@DataClass(changeable: true, buildable: true, copyable: true)
+@DataClass(buildable: true, copyable: true, mergeable: true, changeable: true)
 class $Dollar with _$$Dollar {
   final $Dollar $dollar;
   final $Dollar? euro;

--- a/example/lib/edge_cases.g.dart
+++ b/example/lib/edge_cases.g.dart
@@ -26,6 +26,16 @@ mixin _$$Dollar {
     );
   }
 
+  $Dollar merge(covariant $Dollar? other) {
+    if (other == null) return _self;
+    return $Dollar(
+      $dollar: other.$dollar,
+      euro: other.euro ?? _self.euro,
+      privateAndPublic: other.privateAndPublic,
+      private: other._private,
+    );
+  }
+
   $Dollar change(void Function($DollarChanges c) updates) =>
       (toChanges()..update(updates)).build();
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,16 +14,13 @@ dependencies:
   json_annotation: ^4.9.0
 
 dependency_overrides:
-  class_to_string:
-    path: ../class_to_string
-  mek_data_class:
-    path: ../mek_data_class
+  class_to_string: { path: ../class_to_string }
+  mek_data_class: { path: ../mek_data_class }
 
 dev_dependencies:
   mek_lints: ^2.0.0
   test: ^1.21.6
 
   build_runner: ^2.8.0
-  mek_data_class_generator:
-    path: ../mek_data_class_generator
+  mek_data_class_generator: { path: ../mek_data_class_generator }
   json_serializable: ^6.11.1

--- a/mek_data_class/CHANGELOG.md
+++ b/mek_data_class/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.2.0
+- feat: added `DataClass.mergeable` which generates the `merge` method to copy the values of another instance into the current instance
+
 ## 2.1.0
 - chore: bumped min dart version to `3.8.0`
 

--- a/mek_data_class/lib/mek_data_class.dart
+++ b/mek_data_class/lib/mek_data_class.dart
@@ -33,6 +33,10 @@ class DataClass {
   /// Default: `false`
   final bool? copyable;
 
+  /// Adds the `merge` method to the class.
+  /// Default: `false`
+  final bool? mergeable;
+
   /// Adds the `change` and `toChanges` method to the class.
   /// Default: `false`
   final bool? changeable;
@@ -46,8 +50,9 @@ class DataClass {
   const DataClass({
     this.comparable,
     this.stringify,
-    this.copyable,
     this.buildable,
+    this.copyable,
+    this.mergeable,
     this.changeable,
     this.equalities = const [],
   });

--- a/mek_data_class/pubspec.yaml
+++ b/mek_data_class/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mek_data_class
 description: >
   Generate `hashCode`, `==`, `toString`, `copyWith`, `change` methods and `Builder` class with low code
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/BreX900/data_class/tree/main/mek_data_class
 repository: https://github.com/BreX900/data_class
 topics:

--- a/mek_data_class_generator/CHANGELOG.md
+++ b/mek_data_class_generator/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+
+## 4.2.0
+- feat: added the ability to generate the `merge` method to copy the values of another instance into the current instance
+- fix: fixed missing space when generating an empty const constructor
+- chore: `copyWith` and `merge` methods return the original data class instance if constructor has no parameters
+- chore: allowed analyzer `>=8.1.1 <10.0.0`
+
 ## 4.1.1
 - build: require `analyzer: ^9.0.0`
 - build: require `build: ^4.0.3`

--- a/mek_data_class_generator/lib/mek_data_class_generator.dart
+++ b/mek_data_class_generator/lib/mek_data_class_generator.dart
@@ -10,6 +10,7 @@ import 'package:mek_data_class_generator/src/helpers/change_helper.dart';
 import 'package:mek_data_class_generator/src/helpers/copy_with_helper.dart';
 import 'package:mek_data_class_generator/src/helpers/equatable_helper.dart';
 import 'package:mek_data_class_generator/src/helpers/helper_core.dart';
+import 'package:mek_data_class_generator/src/helpers/merge_helper.dart';
 import 'package:mek_data_class_generator/src/helpers/to_string_helper.dart';
 import 'package:source_gen/source_gen.dart' hide LibraryBuilder;
 import 'package:source_helper/source_helper.dart';
@@ -44,7 +45,7 @@ class DataClassGenerator extends GeneratorForAnnotation<DataClass> {
 }
 
 class _RegistryHelper extends HelperCore
-    with CopyWithHelper, ChangeHelper, BuilderHelper, EquatableHelper, ToStringHelper {
+    with CopyWithHelper, MergeHelper, ChangeHelper, BuilderHelper, EquatableHelper, ToStringHelper {
   final _libraryBody = <Spec>[];
   final _mixinMethods = <Method>[];
   var _shouldCreateSelfMixinGetter = false;

--- a/mek_data_class_generator/lib/src/configs/class_config.dart
+++ b/mek_data_class_generator/lib/src/configs/class_config.dart
@@ -12,14 +12,16 @@ class ClassConfig {
   final bool stringify;
   final bool buildable;
   final bool copyable;
+  final bool mergeable;
   final bool changeable;
   final List<DartObject> equalities;
 
   const ClassConfig({
     required this.comparable,
     required this.stringify,
-    required this.copyable,
     required this.buildable,
+    required this.copyable,
+    required this.mergeable,
     required this.changeable,
     required this.equalities,
   });
@@ -32,6 +34,7 @@ class ClassConfig {
         stringify: false,
         buildable: false,
         copyable: false,
+        mergeable: false,
         changeable: false,
         equalities: [],
       );
@@ -45,6 +48,7 @@ class ClassConfig {
       stringify: annotation.get('stringify')?.boolValue ?? config.stringify,
       buildable: annotation.get('buildable')?.boolValue ?? config.buildable,
       copyable: annotation.get('copyable')?.boolValue ?? config.copyable,
+      mergeable: annotation.get('mergeable')?.boolValue ?? config.mergeable,
       changeable: annotation.get('changeable')?.boolValue ?? config.changeable,
       equalities: annotation.read('equalities').listValue,
     );

--- a/mek_data_class_generator/lib/src/configs/options.dart
+++ b/mek_data_class_generator/lib/src/configs/options.dart
@@ -5,21 +5,30 @@ part 'options.g.dart';
 @JsonSerializable()
 class Options {
   final Object? runOnlyIfTriggered;
+  @JsonKey(defaultValue: true)
   final bool equatable;
+  @JsonKey(defaultValue: true)
   final bool stringify;
+  @JsonKey(defaultValue: true)
   final bool stringifyIfNull;
+  @JsonKey(defaultValue: false)
   final bool buildable;
+  @JsonKey(defaultValue: false)
   final bool copyable;
+  @JsonKey(defaultValue: false)
+  final bool mergeable;
+  @JsonKey(defaultValue: false)
   final bool changeable;
 
   const Options({
-    this.runOnlyIfTriggered,
-    this.equatable = true,
-    this.stringify = true,
-    this.stringifyIfNull = true,
-    this.buildable = false,
-    this.copyable = false,
-    this.changeable = false,
+    required this.runOnlyIfTriggered,
+    required this.equatable,
+    required this.stringify,
+    required this.stringifyIfNull,
+    required this.buildable,
+    required this.copyable,
+    required this.mergeable,
+    required this.changeable,
   });
 
   factory Options.fromJson(Map<String, dynamic> map) => _$OptionsFromJson(map);

--- a/mek_data_class_generator/lib/src/configs/options.g.dart
+++ b/mek_data_class_generator/lib/src/configs/options.g.dart
@@ -19,6 +19,7 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
         'stringify_if_null',
         'buildable',
         'copyable',
+        'mergeable',
         'changeable',
       ],
     );
@@ -26,9 +27,13 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
       runOnlyIfTriggered: $checkedConvert('run_only_if_triggered', (v) => v),
       equatable: $checkedConvert('equatable', (v) => v as bool? ?? true),
       stringify: $checkedConvert('stringify', (v) => v as bool? ?? true),
-      stringifyIfNull: $checkedConvert('stringify_if_null', (v) => v as bool? ?? true),
+      stringifyIfNull: $checkedConvert(
+        'stringify_if_null',
+        (v) => v as bool? ?? true,
+      ),
       buildable: $checkedConvert('buildable', (v) => v as bool? ?? false),
       copyable: $checkedConvert('copyable', (v) => v as bool? ?? false),
+      mergeable: $checkedConvert('mergeable', (v) => v as bool? ?? false),
       changeable: $checkedConvert('changeable', (v) => v as bool? ?? false),
     );
     return val;

--- a/mek_data_class_generator/pubspec.yaml
+++ b/mek_data_class_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mek_data_class_generator
-version: 4.1.1
+version: 4.2.0
 description: >
   Code generator for data_class to generate `hashCode`, `==`, `toString`, `copyWith` 
   and `change` methods
@@ -20,23 +20,21 @@ scripts:
   generate-code: dart run build_runner watch --delete-conflicting-outputs
 
 dependencies:
-  mek_data_class: ^2.0.0
+  mek_data_class: ^2.2.0
 
-  analyzer: ^9.0.0
-  build: ^4.0.3
-  source_gen: ^4.1.1
+  analyzer: '>=8.1.1 <10.0.0'
+  build: ^4.0.2
+  source_gen: ^4.0.0
   code_builder: ^4.4.0
-  source_helper: ^1.3.9
+  source_helper: ^1.3.8
 
   meta: ^1.16.0
   collection: ^1.16.0
   json_annotation: ^4.9.0
 
 dependency_overrides:
-  class_to_string:
-    path: ../class_to_string
-  mek_data_class:
-    path: ../mek_data_class
+  class_to_string: { path: ../class_to_string }
+  mek_data_class: { path: ../mek_data_class }
 
 dev_dependencies:
   mek_lints: ^4.0.0


### PR DESCRIPTION
feat: added the ability to generate the `merge` method to copy the values of another instance into the current instance
fix: fixed missing space when generating an empty const constructor
chore: `copyWith` and `merge` methods return the original data class instance if constructor has no parameters